### PR TITLE
Added support for jakarta namespace

### DIFF
--- a/src/main/kotlin/com/github/nayacco/restfulhelper/annotations/MappingAnnotation.kt
+++ b/src/main/kotlin/com/github/nayacco/restfulhelper/annotations/MappingAnnotation.kt
@@ -1,27 +1,11 @@
 package com.github.nayacco.restfulhelper.annotations
 
-import com.intellij.psi.PsiAnnotation
 import com.github.nayacco.restfulhelper.RequestMappingItem
-import com.github.nayacco.restfulhelper.annotations.jaxrs.DELETE
-import com.github.nayacco.restfulhelper.annotations.jaxrs.GET
-import com.github.nayacco.restfulhelper.annotations.jaxrs.HEAD
-import com.github.nayacco.restfulhelper.annotations.jaxrs.OPTIONS
-import com.github.nayacco.restfulhelper.annotations.jaxrs.PATCH
-import com.github.nayacco.restfulhelper.annotations.jaxrs.POST
-import com.github.nayacco.restfulhelper.annotations.jaxrs.PUT
-import com.github.nayacco.restfulhelper.annotations.micronaut.Delete
-import com.github.nayacco.restfulhelper.annotations.micronaut.Get
-import com.github.nayacco.restfulhelper.annotations.micronaut.Head
-import com.github.nayacco.restfulhelper.annotations.micronaut.Options
-import com.github.nayacco.restfulhelper.annotations.micronaut.Patch
-import com.github.nayacco.restfulhelper.annotations.micronaut.Post
-import com.github.nayacco.restfulhelper.annotations.micronaut.Put
-import com.github.nayacco.restfulhelper.annotations.spring.DeleteMapping
-import com.github.nayacco.restfulhelper.annotations.spring.GetMapping
-import com.github.nayacco.restfulhelper.annotations.spring.PatchMapping
-import com.github.nayacco.restfulhelper.annotations.spring.PostMapping
-import com.github.nayacco.restfulhelper.annotations.spring.PutMapping
-import com.github.nayacco.restfulhelper.annotations.spring.RequestMapping
+import com.github.nayacco.restfulhelper.annotations.jakartars.*
+import com.github.nayacco.restfulhelper.annotations.jaxrs.*
+import com.github.nayacco.restfulhelper.annotations.micronaut.*
+import com.github.nayacco.restfulhelper.annotations.spring.*
+import com.intellij.psi.PsiAnnotation
 
 interface MappingAnnotation {
 
@@ -54,6 +38,7 @@ interface MappingAnnotation {
         )
 
         fun mappingAnnotation(annotationName: String, psiAnnotation: PsiAnnotation): MappingAnnotation {
+            val isJakartaPackage = psiAnnotation.qualifiedName!!.contains(JAKARTARS_PACKAGE_NAME)
             return when (annotationName) {
                 RequestMapping::class.java.simpleName -> RequestMapping(psiAnnotation)
                 GetMapping::class.java.simpleName -> GetMapping(psiAnnotation)
@@ -62,13 +47,13 @@ interface MappingAnnotation {
                 PatchMapping::class.java.simpleName -> PatchMapping(psiAnnotation)
                 DeleteMapping::class.java.simpleName -> DeleteMapping(psiAnnotation)
 
-                GET::class.java.simpleName -> GET(psiAnnotation)
-                PUT::class.java.simpleName -> PUT(psiAnnotation)
-                POST::class.java.simpleName -> POST(psiAnnotation)
-                OPTIONS::class.java.simpleName -> OPTIONS(psiAnnotation)
-                HEAD::class.java.simpleName -> HEAD(psiAnnotation)
-                DELETE::class.java.simpleName -> DELETE(psiAnnotation)
-                PATCH::class.java.simpleName -> PATCH(psiAnnotation)
+                GET::class.java.simpleName -> if (isJakartaPackage) JakartaGet(psiAnnotation) else GET(psiAnnotation)
+                PUT::class.java.simpleName -> if (isJakartaPackage) JakartaPut(psiAnnotation) else PUT(psiAnnotation)
+                POST::class.java.simpleName -> if (isJakartaPackage) JakartaPost(psiAnnotation) else POST(psiAnnotation)
+                OPTIONS::class.java.simpleName -> if (isJakartaPackage) JakartaOptions(psiAnnotation) else OPTIONS(psiAnnotation)
+                HEAD::class.java.simpleName -> if (isJakartaPackage) JakartaHead(psiAnnotation) else HEAD(psiAnnotation)
+                DELETE::class.java.simpleName -> if (isJakartaPackage) JakartaDelete(psiAnnotation) else DELETE(psiAnnotation)
+                PATCH::class.java.simpleName -> if (isJakartaPackage) JakartaPatch(psiAnnotation) else PATCH(psiAnnotation)
 
                 Get::class.java.simpleName -> Get(psiAnnotation)
                 Put::class.java.simpleName -> Put(psiAnnotation)

--- a/src/main/kotlin/com/github/nayacco/restfulhelper/annotations/jakartars/JakartaRsMappingAnnotation.kt
+++ b/src/main/kotlin/com/github/nayacco/restfulhelper/annotations/jakartars/JakartaRsMappingAnnotation.kt
@@ -1,0 +1,77 @@
+package com.github.nayacco.restfulhelper.annotations.jakartars
+
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiLiteralExpression
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiReferenceExpression
+import com.github.nayacco.restfulhelper.RequestMappingItem
+import com.github.nayacco.restfulhelper.annotations.MappingAnnotation
+import com.github.nayacco.restfulhelper.annotations.PathAnnotation
+import com.github.nayacco.restfulhelper.annotations.UrlFormatter
+import com.github.nayacco.restfulhelper.annotations.extraction.PsiExpressionExtractor.extractExpression
+import com.github.nayacco.restfulhelper.model.Path
+import com.github.nayacco.restfulhelper.model.PathParameter
+import com.github.nayacco.restfulhelper.utils.fetchAnnotatedMethod
+
+abstract class JakartaRsMappingAnnotation(
+    private val psiAnnotation: PsiAnnotation,
+    private val urlFormatter: UrlFormatter = JakartaRsUrlFormatter
+) : MappingAnnotation {
+
+    override fun values(): List<RequestMappingItem> =
+        fetchRequestMappingItem(psiAnnotation.fetchAnnotatedMethod(), extractMethod())
+
+    abstract fun extractMethod(): String
+
+    private fun fetchRequestMappingItem(psiMethod: PsiMethod, method: String): List<RequestMappingItem> {
+        val classMapping = fetchMappingFromClass(psiMethod)
+        val methodMapping = fetchMappingFromMethod(psiMethod)
+        return listOf(RequestMappingItem(psiMethod, urlFormatter.format(classMapping, methodMapping), method))
+    }
+
+    private fun fetchMappingFromClass(psiMethod: PsiMethod): String {
+        return psiMethod
+            .containingClass
+            ?.modifierList
+            ?.annotations
+            ?.filter { it.qualifiedName == PATH_ANNOTATION }
+            ?.flatMap { PathAnnotation(it).fetchMappings(ATTRIBUTE_NAME) }
+            ?.firstOrNull() ?: ""
+    }
+
+    private fun fetchMappingFromMethod(method: PsiMethod): String {
+        val parametersNameWithType = method
+            .parameterList
+            .parameters
+            .mapNotNull { PathParameter(it).extractParameterNameWithType(PATH_PARAM_ANNOTATION, ::extractParameterNameFromAnnotation) }
+            .toMap()
+
+        return method
+            .modifierList
+            .annotations
+            .filter { it.qualifiedName == PATH_ANNOTATION }
+            .flatMap { PathAnnotation(it).fetchMappings(ATTRIBUTE_NAME) }
+            .map { Path(it).addPathVariablesTypes(parametersNameWithType).toFullPath() }
+            .firstOrNull() ?: ""
+    }
+
+    private fun extractParameterNameFromAnnotation(annotation: PsiAnnotation, defaultValue: String): String {
+        return when (val pathVariableValue = annotation.findAttributeValue(ATTRIBUTE_NAME)) {
+            is PsiLiteralExpression -> {
+                val expression = extractExpression(pathVariableValue)
+                expression.ifBlank { defaultValue }
+            }
+            is PsiReferenceExpression -> {
+                val expression = extractExpression(pathVariableValue)
+                expression.ifBlank { defaultValue }
+            }
+            else -> defaultValue
+        }
+    }
+
+    companion object {
+        private const val PATH_ANNOTATION = "jakarta.ws.rs.Path"
+        private const val ATTRIBUTE_NAME = "value"
+        private const val PATH_PARAM_ANNOTATION = "jakarta.ws.rs.PathParam"
+    }
+}

--- a/src/main/kotlin/com/github/nayacco/restfulhelper/annotations/jakartars/JakartaRsUrlFormatter.kt
+++ b/src/main/kotlin/com/github/nayacco/restfulhelper/annotations/jakartars/JakartaRsUrlFormatter.kt
@@ -1,0 +1,13 @@
+package com.github.nayacco.restfulhelper.annotations.jakartars
+
+import com.github.nayacco.restfulhelper.annotations.UrlFormatter
+import com.github.nayacco.restfulhelper.utils.dropFirstEmptyStringIfExists
+
+object JakartaRsUrlFormatter : UrlFormatter {
+
+    override fun format(classMapping: String, methodMapping: String, param: String): String {
+        val classPathSeq = classMapping.splitToSequence('/').filterNot { it.isBlank() }
+        val methodPathList = methodMapping.split('/').dropFirstEmptyStringIfExists()
+        return (classPathSeq + methodPathList).joinToString(separator = "/", prefix = "/")
+    }
+}

--- a/src/main/kotlin/com/github/nayacco/restfulhelper/annotations/jakartars/JakartarsAnnotations.kt
+++ b/src/main/kotlin/com/github/nayacco/restfulhelper/annotations/jakartars/JakartarsAnnotations.kt
@@ -1,0 +1,27 @@
+package com.github.nayacco.restfulhelper.annotations.jakartars
+
+import com.intellij.psi.PsiAnnotation
+
+const val JAKARTARS_PACKAGE_NAME = "jakarta.ws.rs"
+
+class JakartaGet(psiAnnotation: PsiAnnotation) : JakartaRsMappingAnnotation(psiAnnotation) {
+    override fun extractMethod() = "GET"
+}
+class JakartaDelete(psiAnnotation: PsiAnnotation) : JakartaRsMappingAnnotation(psiAnnotation) {
+    override fun extractMethod() = "DELETE"
+}
+class JakartaHead(psiAnnotation: PsiAnnotation) : JakartaRsMappingAnnotation(psiAnnotation) {
+    override fun extractMethod() = "HEAD"
+}
+class JakartaOptions(psiAnnotation: PsiAnnotation) : JakartaRsMappingAnnotation(psiAnnotation) {
+    override fun extractMethod() = "OPTIONS"
+}
+class JakartaPatch(psiAnnotation: PsiAnnotation) : JakartaRsMappingAnnotation(psiAnnotation) {
+    override fun extractMethod() = "PATCH"
+}
+class JakartaPost(psiAnnotation: PsiAnnotation) : JakartaRsMappingAnnotation(psiAnnotation) {
+    override fun extractMethod() = "POST"
+}
+class JakartaPut(psiAnnotation: PsiAnnotation) : JakartaRsMappingAnnotation(psiAnnotation) {
+    override fun extractMethod() = "PUT"
+}

--- a/src/main/kotlin/com/github/nayacco/restfulhelper/contributor/RequestMappingByNameContributor.kt
+++ b/src/main/kotlin/com/github/nayacco/restfulhelper/contributor/RequestMappingByNameContributor.kt
@@ -1,16 +1,17 @@
 package com.github.nayacco.restfulhelper.contributor
 
-import com.intellij.navigation.ChooseByNameContributor
-import com.intellij.navigation.NavigationItem
-import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiAnnotation
 import com.github.nayacco.restfulhelper.RequestMappingItem
 import com.github.nayacco.restfulhelper.annotations.MappingAnnotation.Companion.mappingAnnotation
 import com.github.nayacco.restfulhelper.annotations.MappingAnnotation.Companion.supportedAnnotations
+import com.github.nayacco.restfulhelper.annotations.jakartars.JAKARTARS_PACKAGE_NAME
 import com.github.nayacco.restfulhelper.annotations.jaxrs.JAXRS_PACKAGE_NAME
 import com.github.nayacco.restfulhelper.annotations.micronaut.MICRONAUT_PACKAGE_NAME
 import com.github.nayacco.restfulhelper.annotations.spring.SPRING_PACKAGE_NAME
 import com.github.nayacco.restfulhelper.utils.isMethodAnnotation
+import com.intellij.navigation.ChooseByNameContributor
+import com.intellij.navigation.NavigationItem
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiAnnotation
 
 abstract class RequestMappingByNameContributor(
     private var navigationItems: List<RequestMappingItem> = emptyList()
@@ -39,8 +40,9 @@ abstract class RequestMappingByNameContributor(
             .filter { it.isMethodAnnotation() }
             .filter {
                 it.qualifiedName!!.contains(MICRONAUT_PACKAGE_NAME)
-                    || it.qualifiedName!!.contains(SPRING_PACKAGE_NAME)
-                    || it.qualifiedName!!.contains(JAXRS_PACKAGE_NAME)
+                        || it.qualifiedName!!.contains(SPRING_PACKAGE_NAME)
+                        || it.qualifiedName!!.contains(JAXRS_PACKAGE_NAME)
+                        || it.qualifiedName!!.contains(JAKARTARS_PACKAGE_NAME)
             }
             .map { annotation -> mappingAnnotation(annotationName, annotation) }
             .flatMap { mappingAnnotation -> mappingAnnotation.values().asSequence() }


### PR DESCRIPTION
## 🚀 Description
Added support for the `jakarta` namespace. Starting with Jakarta EE 9, the namespace changed from `javax` to `jakarta`.

## 📄 Motivation and Context
This change was necessary because the plugin does not work with newer versions of Jakarta EE. Since, it only scan for `javax`

## 🧪 How Has This Been Tested?
Tested locally in IntelliJ.

## 📦 Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.